### PR TITLE
Fix the FSF's address + AUTHORS' encoding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
 Chris 'Xenon' Hanson, AlphaPixel, LLC (xenon@alphapixel.com) - Conversion to osgAudio, FMOD support
 Anders Backman, VRlab 2004 (andersb@cs.umu.se)
 Alberto Jaspe, (ajaspe@gmail.com)
-Tomas H‰m‰l‰, VRlab, 2002 (tomash@hpc2n.umu.se)
+Tomas H√§m√§l√§, VRlab, 2002 (tomash@hpc2n.umu.se)
 Loic Dachary (loic@dachary.org) - autotools packaging
 Sukender (Benoit Neil - sukender at free dot fr) - CMake scripts

--- a/README
+++ b/README
@@ -59,7 +59,7 @@ All contributions are welcome and will be considered for inclusion in the projec
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 OpenSceneGraph Audio Library - osgAudio is a small library for adding 3D sound support to the

--- a/examples/openalpp/capture.cpp
+++ b/examples/openalpp/capture.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #define _USE_MATH_DEFINES 
 #include <cmath>

--- a/examples/openalpp/moving.cpp
+++ b/examples/openalpp/moving.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #include <openalpp/Source.h>
 

--- a/examples/openalpp/multiple.cpp
+++ b/examples/openalpp/multiple.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/Source.h>

--- a/examples/openalpp/multiple_oggstreams.cpp
+++ b/examples/openalpp/multiple_oggstreams.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #define _USE_MATH_DEFINES 
 #include <cmath>

--- a/examples/openalpp/playOgg.cpp
+++ b/examples/openalpp/playOgg.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #define _USE_MATH_DEFINES 
 #include <cmath>

--- a/examples/openalpp/simple.cpp
+++ b/examples/openalpp/simple.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <iostream>

--- a/examples/openalpp/testfstream.cpp
+++ b/examples/openalpp/testfstream.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/Source.h>

--- a/examples/openalpp/testmic.cpp
+++ b/examples/openalpp/testmic.cpp
@@ -25,7 +25,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  *
  * Example where sound is streamed from a microphone.
  */

--- a/examples/openalpp/testsend.cpp
+++ b/examples/openalpp/testsend.cpp
@@ -25,7 +25,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  *
  * Example where a soundfile is loaded using alutLoadWav and streamed over a
  * UDP socket to a receiver that will read the datastream and play it.

--- a/examples/openalpp/teststream.cpp
+++ b/examples/openalpp/teststream.cpp
@@ -26,7 +26,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  *
  * Example where a soundfile is loaded using alutLoadWav and streamed over a UDP socket
  * to a receiver that will read the datastream and play it.

--- a/examples/osgaudio-lowlevel/capture.cpp
+++ b/examples/osgaudio-lowlevel/capture.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #define _USE_MATH_DEFINES 
 #include <cmath>

--- a/examples/osgaudio-lowlevel/moving.cpp
+++ b/examples/osgaudio-lowlevel/moving.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #include <osgAudio/Source.h>
 #include <osgAudio/AudioEnvironment.h> // necessary for 3D spatial audio update()

--- a/examples/osgaudio-lowlevel/multiple.cpp
+++ b/examples/osgaudio-lowlevel/multiple.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Source.h>

--- a/examples/osgaudio-lowlevel/multiple_oggstreams.cpp
+++ b/examples/osgaudio-lowlevel/multiple_oggstreams.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #define _USE_MATH_DEFINES 
 #include <cmath>

--- a/examples/osgaudio-lowlevel/playOgg.cpp
+++ b/examples/osgaudio-lowlevel/playOgg.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #define _USE_MATH_DEFINES 
 #include <cmath>

--- a/examples/osgaudio-lowlevel/simple.cpp
+++ b/examples/osgaudio-lowlevel/simple.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <iostream>

--- a/examples/osgaudio-lowlevel/testfstream.cpp
+++ b/examples/osgaudio-lowlevel/testfstream.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Source.h>

--- a/examples/osgaudio-lowlevel/testmic.cpp
+++ b/examples/osgaudio-lowlevel/testmic.cpp
@@ -25,7 +25,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  *
  * Example where sound is streamed from a microphone.
  */

--- a/examples/osgaudio-lowlevel/testsend.cpp
+++ b/examples/osgaudio-lowlevel/testsend.cpp
@@ -26,7 +26,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  *
  * Example where a soundfile is loaded using alutLoadWav and streamed over a
  * UDP socket to a receiver that will read the datastream and play it.

--- a/examples/osgaudio-lowlevel/teststream.cpp
+++ b/examples/osgaudio-lowlevel/teststream.cpp
@@ -26,7 +26,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  *
  * Example where a soundfile is loaded using alutLoadWav and streamed over a UDP socket
  * to a receiver that will read the datastream and play it.

--- a/examples/osgaudio/osgaudio.cpp
+++ b/examples/osgaudio/osgaudio.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/examples/osgaudiomultiple/osgaudiomultiple.cpp
+++ b/examples/osgaudiomultiple/osgaudiomultiple.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/examples/osgaudioocclude/osgaudioocclude.cpp
+++ b/examples/osgaudioocclude/osgaudioocclude.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osg/DeleteHandler>

--- a/examples/osgaudioviewer/osgaudioviewer.cpp
+++ b/examples/osgaudioviewer/osgaudioviewer.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osg/DeleteHandler>

--- a/include/openalpp/AudioBase.h
+++ b/include/openalpp/AudioBase.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_AUDIOBASE_H

--- a/include/openalpp/AudioConvert.h
+++ b/include/openalpp/AudioConvert.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_AUDIOCONVERT_H

--- a/include/openalpp/AudioEnvironment.h
+++ b/include/openalpp/AudioEnvironment.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_AUDIOENVIROMENT_H

--- a/include/openalpp/Capture.h
+++ b/include/openalpp/Capture.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/include/openalpp/DeviceUpdater.h
+++ b/include/openalpp/DeviceUpdater.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_DEVICEUPDATER_H

--- a/include/openalpp/Error.h
+++ b/include/openalpp/Error.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_ERROR_H

--- a/include/openalpp/Export.h
+++ b/include/openalpp/Export.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_EXPORT_H

--- a/include/openalpp/FileStream.h
+++ b/include/openalpp/FileStream.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_FILESTREAM_H

--- a/include/openalpp/FileStreamUpdater.h
+++ b/include/openalpp/FileStreamUpdater.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_FILESTREAMUPDATER_H

--- a/include/openalpp/GroupSource.h
+++ b/include/openalpp/GroupSource.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_GROUPSOURCE_H

--- a/include/openalpp/InputDevice.h
+++ b/include/openalpp/InputDevice.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/include/openalpp/Listener.h
+++ b/include/openalpp/Listener.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_LISTENER_H

--- a/include/openalpp/NetStream.h
+++ b/include/openalpp/NetStream.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/include/openalpp/NetUpdater.h
+++ b/include/openalpp/NetUpdater.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_NETUPDATER_H

--- a/include/openalpp/PositionedObject.h
+++ b/include/openalpp/PositionedObject.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_POSITIONEDOBJECT_H

--- a/include/openalpp/Sample.h
+++ b/include/openalpp/Sample.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_SAMPLE_H

--- a/include/openalpp/SoundData.h
+++ b/include/openalpp/SoundData.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_SOUNDDATA_H

--- a/include/openalpp/Source.h
+++ b/include/openalpp/Source.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_SOURCE_H

--- a/include/openalpp/SourceBase.h
+++ b/include/openalpp/SourceBase.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_SOURCEBASE_H

--- a/include/openalpp/Stream.h
+++ b/include/openalpp/Stream.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_STREAM_H

--- a/include/openalpp/StreamUpdater.h
+++ b/include/openalpp/StreamUpdater.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_STREAMUPDATER_H

--- a/include/openalpp/config.h
+++ b/include/openalpp/config.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_CONFIG_H

--- a/include/openalpp/windowsstuff.h
+++ b/include/openalpp/windowsstuff.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OPENALPP_WINDOWSSTUFF_H

--- a/include/osgAudio/AudioEnvironment.h
+++ b/include/osgAudio/AudioEnvironment.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_AUDIOENVIRONMENT_H

--- a/include/osgAudio/BackendFMOD/AudioEnvironmentFMOD.h
+++ b/include/osgAudio/BackendFMOD/AudioEnvironmentFMOD.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_AUDIOENVIRONMENT_FMOD_H

--- a/include/osgAudio/BackendFMOD/FileStreamFMOD.h
+++ b/include/osgAudio/BackendFMOD/FileStreamFMOD.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_FILESTREAMFMOD_H

--- a/include/osgAudio/BackendFMOD/ListenerFMOD.h
+++ b/include/osgAudio/BackendFMOD/ListenerFMOD.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_LISTENER_FMOD_H

--- a/include/osgAudio/BackendFMOD/SampleFMOD.h
+++ b/include/osgAudio/BackendFMOD/SampleFMOD.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_SAMPLEFMOD_H

--- a/include/osgAudio/BackendFMOD/SoundFMOD.h
+++ b/include/osgAudio/BackendFMOD/SoundFMOD.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_SOUNDFMOD_H

--- a/include/osgAudio/BackendFMOD/SourceFMOD.h
+++ b/include/osgAudio/BackendFMOD/SourceFMOD.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_SOURCEFMOD_H

--- a/include/osgAudio/BackendFMOD/StreamFMOD.h
+++ b/include/osgAudio/BackendFMOD/StreamFMOD.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_STREAMFMOD_H

--- a/include/osgAudio/BackendOpenALpp/AudioEnvironmentOpenALpp.h
+++ b/include/osgAudio/BackendOpenALpp/AudioEnvironmentOpenALpp.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_AUDIOENVIRONMENT_OPENALPP_H

--- a/include/osgAudio/BackendOpenALpp/FileStreamOpenALpp.h
+++ b/include/osgAudio/BackendOpenALpp/FileStreamOpenALpp.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_FILESTREAMOPENALPP_H_H

--- a/include/osgAudio/BackendOpenALpp/ListenerOpenALpp.h
+++ b/include/osgAudio/BackendOpenALpp/ListenerOpenALpp.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_LISTENER_OPENALPP_H

--- a/include/osgAudio/BackendOpenALpp/SampleOpenALpp.h
+++ b/include/osgAudio/BackendOpenALpp/SampleOpenALpp.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_SAMPLEOPENALPP_H_H

--- a/include/osgAudio/BackendOpenALpp/SourceOpenALpp.h
+++ b/include/osgAudio/BackendOpenALpp/SourceOpenALpp.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_SOURCEOPENALPP_H

--- a/include/osgAudio/BackendOpenALpp/StreamOpenALpp.h
+++ b/include/osgAudio/BackendOpenALpp/StreamOpenALpp.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_STREAMOPENALPP_H

--- a/include/osgAudio/Config.h
+++ b/include/osgAudio/Config.h
@@ -19,7 +19,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/include/osgAudio/Config.h.in
+++ b/include/osgAudio/Config.h.in
@@ -19,7 +19,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/include/osgAudio/Error.h
+++ b/include/osgAudio/Error.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 // This file is taken directly from openAL++ Error header

--- a/include/osgAudio/Export.h
+++ b/include/osgAudio/Export.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_EXPORT_H

--- a/include/osgAudio/FileStream.h
+++ b/include/osgAudio/FileStream.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_FILESTREAM_H

--- a/include/osgAudio/Listener.h
+++ b/include/osgAudio/Listener.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_LISTENER_H

--- a/include/osgAudio/Math.h
+++ b/include/osgAudio/Math.h
@@ -21,7 +21,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/include/osgAudio/OccludeCallback.h
+++ b/include/osgAudio/OccludeCallback.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_OCCLUDECALLBACK_H

--- a/include/osgAudio/Sample.h
+++ b/include/osgAudio/Sample.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_SAMPLE_H

--- a/include/osgAudio/SoundDefaults.h
+++ b/include/osgAudio/SoundDefaults.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/include/osgAudio/SoundManager.h
+++ b/include/osgAudio/SoundManager.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/include/osgAudio/SoundNode.h
+++ b/include/osgAudio/SoundNode.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #ifndef OSGAUDIO_SOUNDNODE_H
 #define OSGAUDIO_SOUNDNODE_H 1

--- a/include/osgAudio/SoundRoot.h
+++ b/include/osgAudio/SoundRoot.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #ifndef OSGAUDIO_SOUNDROOT_H
 #define OSGAUDIO_SOUNDROOT_H 1

--- a/include/osgAudio/SoundState.h
+++ b/include/osgAudio/SoundState.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/include/osgAudio/SoundUpdateCB.h
+++ b/include/osgAudio/SoundUpdateCB.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #ifndef OSGAUDIO_SOUND_UPDATE_CB_H
 #define OSGAUDIO_SOUND_UPDATE_CB_H 1

--- a/include/osgAudio/Source.h
+++ b/include/osgAudio/Source.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_SOURCE_H

--- a/include/osgAudio/SourceBase.h
+++ b/include/osgAudio/SourceBase.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_SOURCEBASE_H

--- a/include/osgAudio/Stream.h
+++ b/include/osgAudio/Stream.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_STREAM_H

--- a/include/osgAudio/Version.h
+++ b/include/osgAudio/Version.h
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_VERSION_H

--- a/include/osgAudio/Version.h.in
+++ b/include/osgAudio/Version.h.in
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #ifndef OSGAUDIO_VERSION_H

--- a/src/openalpp/AudioBase.cpp
+++ b/src/openalpp/AudioBase.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include "stdio.h"

--- a/src/openalpp/AudioConvert.cpp
+++ b/src/openalpp/AudioConvert.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <iostream>

--- a/src/openalpp/AudioEnvironment.cpp
+++ b/src/openalpp/AudioEnvironment.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #include <openalpp/AudioEnvironment.h>
 #include <openalpp/windowsstuff.h>

--- a/src/openalpp/Capture.cpp
+++ b/src/openalpp/Capture.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/DeviceUpdater.h>

--- a/src/openalpp/DeviceUpdater.cpp
+++ b/src/openalpp/DeviceUpdater.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/DeviceUpdater.h>

--- a/src/openalpp/Error.cpp
+++ b/src/openalpp/Error.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/Error.h>

--- a/src/openalpp/FileStream.cpp
+++ b/src/openalpp/FileStream.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <sstream>

--- a/src/openalpp/FileStreamUpdater.cpp
+++ b/src/openalpp/FileStreamUpdater.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/FileStreamUpdater.h>

--- a/src/openalpp/GroupSource.cpp
+++ b/src/openalpp/GroupSource.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <sstream>

--- a/src/openalpp/InputDevice.cpp
+++ b/src/openalpp/InputDevice.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/DeviceUpdater.h>

--- a/src/openalpp/Listener.cpp
+++ b/src/openalpp/Listener.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #include <openalpp/Listener.h>
 

--- a/src/openalpp/NetStream.cpp
+++ b/src/openalpp/NetStream.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #ifdef ALPP_USE_NETSTREAM
 

--- a/src/openalpp/NetUpdater.cpp
+++ b/src/openalpp/NetUpdater.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #ifdef ALPP_USE_NETSTREAM
 

--- a/src/openalpp/NoFileStream.cpp
+++ b/src/openalpp/NoFileStream.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/FileStream.h>

--- a/src/openalpp/NoInputDevice.cpp
+++ b/src/openalpp/NoInputDevice.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/InputDevice.h>

--- a/src/openalpp/NoStreaming.cpp
+++ b/src/openalpp/NoStreaming.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/Stream.h>

--- a/src/openalpp/Openalpp.cpp
+++ b/src/openalpp/Openalpp.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/Export.h>

--- a/src/openalpp/Sample.cpp
+++ b/src/openalpp/Sample.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <sstream>

--- a/src/openalpp/SoundData.cpp
+++ b/src/openalpp/SoundData.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 #include <openalpp/SoundData.h>
 

--- a/src/openalpp/Source.cpp
+++ b/src/openalpp/Source.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/Source.h>

--- a/src/openalpp/SourceBase.cpp
+++ b/src/openalpp/SourceBase.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <sstream>

--- a/src/openalpp/Stream.cpp
+++ b/src/openalpp/Stream.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <openalpp/StreamUpdater.h>

--- a/src/openalpp/StreamUpdater.cpp
+++ b/src/openalpp/StreamUpdater.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 // TODO: Need to update this so that frequency and format can be changed after

--- a/src/osgAudio/BackendFMOD/AudioEnvironmentFMOD.cpp
+++ b/src/osgAudio/BackendFMOD/AudioEnvironmentFMOD.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/AudioEnvironment.h>

--- a/src/osgAudio/BackendFMOD/FileStreamFMOD.cpp
+++ b/src/osgAudio/BackendFMOD/FileStreamFMOD.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/FileStream.h>

--- a/src/osgAudio/BackendFMOD/ListenerFMOD.cpp
+++ b/src/osgAudio/BackendFMOD/ListenerFMOD.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Listener.h>

--- a/src/osgAudio/BackendFMOD/SampleFMOD.cpp
+++ b/src/osgAudio/BackendFMOD/SampleFMOD.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Sample.h>

--- a/src/osgAudio/BackendFMOD/SourceFMOD.cpp
+++ b/src/osgAudio/BackendFMOD/SourceFMOD.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <cassert>

--- a/src/osgAudio/BackendFMOD/StreamFMOD.cpp
+++ b/src/osgAudio/BackendFMOD/StreamFMOD.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Stream.h>

--- a/src/osgAudio/BackendOpenALpp/AudioEnvironmentOpenALpp.cpp
+++ b/src/osgAudio/BackendOpenALpp/AudioEnvironmentOpenALpp.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/AudioEnvironment.h>

--- a/src/osgAudio/BackendOpenALpp/FileStreamOpenALpp.cpp
+++ b/src/osgAudio/BackendOpenALpp/FileStreamOpenALpp.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/FileStream.h>

--- a/src/osgAudio/BackendOpenALpp/ListenerOpenALpp.cpp
+++ b/src/osgAudio/BackendOpenALpp/ListenerOpenALpp.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Listener.h>

--- a/src/osgAudio/BackendOpenALpp/SampleOpenALpp.cpp
+++ b/src/osgAudio/BackendOpenALpp/SampleOpenALpp.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Sample.h>

--- a/src/osgAudio/BackendOpenALpp/SourceOpenALpp.cpp
+++ b/src/osgAudio/BackendOpenALpp/SourceOpenALpp.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Source.h>

--- a/src/osgAudio/BackendOpenALpp/StreamOpenALpp.cpp
+++ b/src/osgAudio/BackendOpenALpp/StreamOpenALpp.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Stream.h>

--- a/src/osgAudio/Error.cpp
+++ b/src/osgAudio/Error.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Error.h>

--- a/src/osgAudio/FileStream.cpp
+++ b/src/osgAudio/FileStream.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/FileStream.h>

--- a/src/osgAudio/Listener.cpp
+++ b/src/osgAudio/Listener.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Listener.h>

--- a/src/osgAudio/OccludeCallback.cpp
+++ b/src/osgAudio/OccludeCallback.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <iostream>

--- a/src/osgAudio/Sample.cpp
+++ b/src/osgAudio/Sample.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Sample.h>

--- a/src/osgAudio/SoundDefaults.cpp
+++ b/src/osgAudio/SoundDefaults.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/SoundDefaults.h>

--- a/src/osgAudio/SoundManager.cpp
+++ b/src/osgAudio/SoundManager.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <cassert>

--- a/src/osgAudio/SoundNode.cpp
+++ b/src/osgAudio/SoundNode.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <iomanip>

--- a/src/osgAudio/SoundRoot.cpp
+++ b/src/osgAudio/SoundRoot.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/src/osgAudio/SoundState.cpp
+++ b/src/osgAudio/SoundState.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 // Force the use of the stl max function not the windows.h function

--- a/src/osgAudio/SoundUpdateCB.cpp
+++ b/src/osgAudio/SoundUpdateCB.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/SoundUpdateCB.h>

--- a/src/osgAudio/Source.cpp
+++ b/src/osgAudio/Source.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Source.h>

--- a/src/osgAudio/Stream.cpp
+++ b/src/osgAudio/Stream.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/Stream.h>

--- a/src/osgAudio/Version.cpp
+++ b/src/osgAudio/Version.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/src/osgPlugin/IO_OccludeCallback.cpp
+++ b/src/osgPlugin/IO_OccludeCallback.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/OccludeCallback.h>

--- a/src/osgPlugin/IO_SoundNode.cpp
+++ b/src/osgPlugin/IO_SoundNode.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/SoundNode.h>

--- a/src/osgPlugin/IO_SoundRoot.cpp
+++ b/src/osgPlugin/IO_SoundRoot.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/SoundRoot.h>

--- a/src/osgPlugin/IO_SoundState.cpp
+++ b/src/osgPlugin/IO_SoundState.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 

--- a/src/osgPlugin/IO_SoundUpdateCB.cpp
+++ b/src/osgPlugin/IO_SoundUpdateCB.cpp
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA.
  */
 
 #include <osgAudio/SoundUpdateCB.h>


### PR DESCRIPTION
Fix the FSF's address as per COPYING, as the old address triggers rpmlint's incorrect-fsf-address.
Fix AUTHORS' encoding (switch to UTF-8).
