### PR TITLE
(very) partial revert of 57e7a56cffb78b36bfdc961b78f721c2f552345b

### DIFF
--- a/include/openalpp/AudioBase.h
+++ b/include/openalpp/AudioBase.h
@@ -39,6 +39,7 @@
 
 #include <openalpp/Export.h>
 #include <openalpp/Error.h>
+#include <openalpp/windowsstuff.h>
 
 
 /**

--- a/src/openalpp/AudioBase.cpp
+++ b/src/openalpp/AudioBase.cpp
@@ -27,7 +27,6 @@
 #include <sstream>
 
 #include <openalpp/AudioBase.h>
-#include <openalpp/windowsstuff.h>
 
 using namespace openalpp;
 


### PR DESCRIPTION
NB:` I do not have VC++ so I haven't tested on Windows.

ChangeLog:
- fix building on *NIX (Fedora, openal-soft-1.17.1 + OpenSceneGraph-3.4.0)
  by adding windowsstuff.h to AudioBase.h again
- the alternative is to:
  - `#define` OPENAL_VERSION 2007 // in `AudioBase.h`
  - add to most samples:
    `#ifndef WIN32
    #include <unistd.h>
    #endif`
